### PR TITLE
Commented out the gateway service

### DIFF
--- a/src/main/docker/app.yml
+++ b/src/main/docker/app.yml
@@ -1,20 +1,20 @@
 version: '2'
 services:
-  gateway-app:
-    image: gateway
-    environment:
-      - _JAVA_OPTIONS=-Xmx512m -Xms256m
-      - SPRING_PROFILES_ACTIVE=prod,swagger
-      - MANAGEMENT_METRICS_EXPORT_PROMETHEUS_ENABLED=true
-      - EUREKA_CLIENT_SERVICE_URL_DEFAULTZONE=http://admin:$${jhipster.registry.password}@jhipster-registry:8761/eureka
-      - SPRING_CLOUD_CONFIG_URI=http://admin:$${jhipster.registry.password}@jhipster-registry:8761/config
-      - SPRING_DATASOURCE_URL=jdbc:postgresql://gateway-postgresql:5432/Gateway
-      - SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_OIDC_ISSUER_URI=http://keycloak:9080/auth/realms/jhipster
-      - SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_OIDC_CLIENT_ID=web_app
-      - SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_OIDC_CLIENT_SECRET=web_app
-      - JHIPSTER_SLEEP=30 # gives time for other services to boot before the application
-    ports:
-      - 8080:8080
+# gateway-app:
+#   image: gateway
+#   environment:
+#     - _JAVA_OPTIONS=-Xmx512m -Xms256m
+#     - SPRING_PROFILES_ACTIVE=prod,swagger
+#     - MANAGEMENT_METRICS_EXPORT_PROMETHEUS_ENABLED=true
+#     - EUREKA_CLIENT_SERVICE_URL_DEFAULTZONE=http://admin:$${jhipster.registry.password}@jhipster-registry:8761/eureka
+#     - SPRING_CLOUD_CONFIG_URI=http://admin:$${jhipster.registry.password}@jhipster-registry:8761/config
+#     - SPRING_DATASOURCE_URL=jdbc:postgresql://gateway-postgresql:5432/Gateway
+#     - SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_OIDC_ISSUER_URI=http://keycloak:9080/auth/realms/jhipster
+#     - SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_OIDC_CLIENT_ID=web_app
+#     - SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_OIDC_CLIENT_SECRET=web_app
+#     - JHIPSTER_SLEEP=30 # gives time for other services to boot before the application
+#   ports:
+#     - 8080:8080
   gateway-postgresql:
     extends:
       file: postgresql.yml


### PR DESCRIPTION
This way you don't have to launch all services manually if you want to work on a project locally. We're removing the docker container for the service that you're going to run on your host machine through IntelliJ, which allows you to start the Backend Environment in one swoop using app.yml.